### PR TITLE
Add argument validation to Main

### DIFF
--- a/src/jp/livlog/numexp/Main.java
+++ b/src/jp/livlog/numexp/Main.java
@@ -6,6 +6,10 @@ import jp.livlog.numexp.normalizeNumexp.impl.NormalizeNumexpImpl;
 public class Main {
 
     public static void main(String[] args) {
+        if (args.length < 2) {
+            System.err.println("Usage: java jp.livlog.numexp.Main <language> <text>");
+            return;
+        }
 
         final var language = args[0];
         final var text = args[1];


### PR DESCRIPTION
## Summary
- avoid ArrayIndexOutOfBounds by checking command-line arguments in `Main`

## Testing
- `mvn -q -DskipTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b4539b08321845f281dc56f8588